### PR TITLE
Add comment to empty catch clause

### DIFF
--- a/src/main/java/echo/Echo.java
+++ b/src/main/java/echo/Echo.java
@@ -13,11 +13,11 @@ public class Echo {
     private TaskManager taskManager;
 
     public Echo(Path path) {
-        this.storage = new Storage(path);
         try {
+            this.storage = new Storage(path);
             this.taskManager = this.storage.createTaskManager();
         } catch (IOException e) {
-
+            Platform.exit();
         }
     }
 

--- a/src/main/java/echo/Storage.java
+++ b/src/main/java/echo/Storage.java
@@ -15,15 +15,14 @@ import java.util.Scanner;
 public class Storage {
     private Path path;
 
-    public Storage(Path path) {
+    public Storage(Path path) throws IOException {
         this.path = path;
         try {
             Files.createDirectories(path.getParent());
             Files.createFile(path);
         } catch (FileAlreadyExistsException e) {
-
-        } catch (IOException e) {
-            Ui.getFileWarning();
+            // This catch clause is empty as this exception is only raised if the data file already exists.
+            // No further action needs to be taken as the chatbot should just read from this file subsequently.
         }
     }
 


### PR DESCRIPTION
An empty catch clause indicates that an error is being handled silently. Adding a comment behind the rationale of an empty catch clause can help future debugging and for clarity purposes.